### PR TITLE
docs: update deployment output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm run build
 
 1. Создайте проект на [Vercel](https://vercel.com/) и подключите репозиторий.
 2. В разделе **Environment Variables** задайте `REACT_APP_SUPABASE_PROJECT_ID` и `REACT_APP_SUPABASE_ANON_KEY`.
-3. Укажите команду сборки `npm run build` и директорию вывода `dist`.
+3. Укажите команду сборки `npm run build` и директорию вывода `build`.
 4. После пуша в основную ветку Vercel автоматически выполнит сборку и развернёт приложение.
 
 ## Устранение неполадок


### PR DESCRIPTION
## Summary
- clarify that Vercel should use the `build` directory produced by `npm run build`

## Testing
- `npm test` *(fails: Missing script "test")*
- `REACT_APP_SUPABASE_PROJECT_ID=foo REACT_APP_SUPABASE_ANON_KEY=bar npm run build` *(fails: Rollup failed to resolve import "sonner@2.0.3")*

------
https://chatgpt.com/codex/tasks/task_e_68affed2154c8333ba5348d7ae8b4cca