### PR TITLE
chore: specify dependency versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@radix-ui/react-tooltip": "^1.1.8",
         "@supabase/supabase-js": "^2.56.0",
         "class-variance-authority": "^0.7.1",
-        "clsx": "*",
+        "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "embla-carousel-react": "^8.6.0",
         "hono": "npm:hono@^4.9.4",
@@ -50,7 +50,7 @@
         "react-resizable-panels": "^2.1.7",
         "recharts": "^2.15.2",
         "sonner": "^2.0.3",
-        "tailwind-merge": "*",
+        "tailwind-merge": "^3.3.1",
         "vaul": "^1.1.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
     "class-variance-authority": "^0.7.1",
-    "clsx": "*",
+    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
@@ -43,7 +43,7 @@
     "react-resizable-panels": "^2.1.7",
     "recharts": "^2.15.2",
     "sonner": "^2.0.3",
-    "tailwind-merge": "*",
+    "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
     "@supabase/supabase-js": "^2.56.0",
     "hono": "npm:hono@^4.9.4"


### PR DESCRIPTION
## Summary
- replace wildcard dependencies with explicit versions
- run `npm install` to sync lockfile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "sonner@2.0.3")*

------
https://chatgpt.com/codex/tasks/task_e_68affed35dd083338bba2d26d752bb76